### PR TITLE
Add mixinDirectory variable to enable the use of relative paths in mixins

### DIFF
--- a/src/Template.ts
+++ b/src/Template.ts
@@ -188,13 +188,14 @@ class Template {
    * @returns {Array}
    */
   setMixinPositions (str: string, originalIndentation = 2): any[] {
-    const regexp = RegExp(/(mixin\(.*\))/, 'g');
+    const regexp = RegExp(/(mixin\(["'`]([^"`']*)["'`].*\))/, 'g');
     let matches;
     const matched: any[] = [];
     while ((matches = regexp.exec(str)) !== null) {
       const mixinObj = {
         index: regexp.lastIndex,
         match: matches[0],
+        mixinPath: matches[2],
         mixinLinePadding: ''
       };
       const indent = calculateIndentFromLineBreak(str, mixinObj.index) + originalIndentation;

--- a/src/__tests__/Template.spec.ts
+++ b/src/__tests__/Template.spec.ts
@@ -21,11 +21,13 @@ describe('setMixinPositions', () => {
         {
           index: 33,
           match: "mixin('some/path', 321)",
+          mixinPath: "some/path",
           mixinLinePadding: '  ',
         },
         {
           index: 77,
           match: "mixin('some/pther/path', 654654)",
+          mixinPath: "some/pther/path",
           mixinLinePadding: '  ',
         },
       ])
@@ -39,11 +41,13 @@ describe('setMixinPositions', () => {
         {
           index: 43,
           match: "mixin('some/path', 321)",
+          mixinPath: "some/path",
           mixinLinePadding: '  ',
         },
         {
           index: 97,
           match: "mixin('some/other/path', 654654)",
+          mixinPath: "some/other/path",
           mixinLinePadding: '  ',
         },
       ])

--- a/src/__tests__/buildFilesData/builtOA3.json
+++ b/src/__tests__/buildFilesData/builtOA3.json
@@ -26,6 +26,47 @@
     }
   ],
   "paths": {
+    "/relative": {
+      "get": {
+         "tags": [
+            "Relative"
+         ],
+         "summary": "Example Relative Mixin Path",
+         "description": "Use a mixin which contains a relative path",
+         "operationId": "relativeGet",
+         "responses": {
+            "200": {
+               "description": "Successful fetch",
+               "content": {
+                  "application/json": {
+                     "schema": {
+                        "type": "object",
+                        "properties": {
+                           "included": {
+                              "type": "object",
+                              "properties": {
+                                 "one": {
+                                    "type": "string"
+                                 }
+                              }
+                           },
+                           "data": {
+                              "type": "array",
+                              "items": {
+                                 "$ref": "#/components/schemas/Weathers"
+                              }
+                           }
+                        }
+                     }
+                  }
+               }
+            },
+            "404": {
+               "description": "Temp not found"
+            }
+         }
+      }
+    },
     "/weather": {
       "get": {
         "tags": [

--- a/src/__tests__/buildFilesData/builtOA3_exclude.json
+++ b/src/__tests__/buildFilesData/builtOA3_exclude.json
@@ -26,6 +26,47 @@
     }
   ],
   "paths": {
+    "/relative": {
+      "get": {
+         "tags": [
+            "Relative"
+         ],
+         "summary": "Example Relative Mixin Path",
+         "description": "Use a mixin which contains a relative path",
+         "operationId": "relativeGet",
+         "responses": {
+            "200": {
+               "description": "Successful fetch",
+               "content": {
+                  "application/json": {
+                     "schema": {
+                        "type": "object",
+                        "properties": {
+                           "included": {
+                              "type": "object",
+                              "properties": {
+                                 "one": {
+                                    "type": "string"
+                                 }
+                              }
+                           },
+                           "data": {
+                              "type": "array",
+                              "items": {
+                                 "$ref": "#/components/schemas/Weathers"
+                              }
+                           }
+                        }
+                     }
+                  }
+               }
+            },
+            "404": {
+               "description": "Temp not found"
+            }
+         }
+      }
+    },
     "/weather": {
       "get": {
         "tags": [

--- a/src/nunjucksHelpers/mixin.ts
+++ b/src/nunjucksHelpers/mixin.ts
@@ -2,6 +2,8 @@ import path from 'path';
 import fs from 'fs-extra';
 import nunjucks from 'nunjucks';
 
+const mixinDirectoryKey = 'mixinDirectory';
+
 export default function (): string {
   const tplGlobals = this.env.globals;
   // eslint-disable-next-line prefer-rest-params
@@ -9,7 +11,13 @@ export default function (): string {
   if (!fs.pathExistsSync(renderPath)) {
     throw new Error('Path not found when trying to render mixin: ' + renderPath);
   }
+
   const vars: any = {};
+
+  const mixinObj = tplGlobals.mixinObject[tplGlobals.mixinNumber];
+
+  vars[mixinDirectoryKey] = path.dirname(mixinObj.mixinPath)
+
   let skipAutoIndex = false;
   for (let i = 1; i < arguments.length; ++i) {
     if (arguments[i] === '--skip-auto-indent') {
@@ -27,7 +35,7 @@ export default function (): string {
   } else {
     const parts = rendered.split('\n');
     parts.forEach((part, i) => {
-      parts[i] = tplGlobals.mixinObject[tplGlobals.mixinNumber].mixinLinePadding + part;
+      parts[i] = mixinObj.mixinLinePadding + part;
     });
     ++this.env.globals.mixinNumber;
     return replaceVal + parts.join('\n');

--- a/srcOA3/mixins/response/relativePaths.yml.njk
+++ b/srcOA3/mixins/response/relativePaths.yml.njk
@@ -1,0 +1,10 @@
+application/json:
+  schema:
+    type: object
+    properties:
+      included:
+        $ref: {{ mixinDirectory }}/standard.yml.njk
+      data:
+        type: array
+        items:
+          $ref: {{ var1 }}

--- a/srcOA3/mixins/response/standard.yml.njk
+++ b/srcOA3/mixins/response/standard.yml.njk
@@ -1,0 +1,4 @@
+type: object
+properties:
+  one:
+    type: string

--- a/srcOA3/paths/relative/get.yml.njk
+++ b/srcOA3/paths/relative/get.yml.njk
@@ -1,0 +1,11 @@
+tags:
+  - {{ autoTag() }}
+summary: Example Relative Mixin Path
+description: Use a mixin which contains a relative path
+operationId: {{ uniqueOpId() }}
+responses:
+  '200':
+    description: Successful fetch
+    content: {{ mixin("../../mixins/response/relativePaths.yml.njk", "../../components/schemas/weather/models.yml.njk") }}
+  '404':
+    description: Temp not found


### PR DESCRIPTION
Scratching an itch.

Use Case: We would like to use a mixin to import blocks that reference other schema files.

(mostly, import all the common error responses in a big block)

So, have added a `{{ mixinDirectory }}` variable to use in mixins that gives the correct path when used with a relative path.