### PR TITLE
Enable AsyncAPI3 when --init is called

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,8 @@ An OpenAPI & AsyncAPI templating system with Nunjucks... write less YAML... do m
 ___
 
 ## Quick start
-- Create a new project, `npm init`
-- Install boats, `npm i --save boats`
-- Add to the scripts, `... "scripts": {"boats": "boats"} ...`
-- Run BOATS init, `npm run boats -- --init`, follow prompts
+- Create a new project, `npm init -y`
+- Run BOATS init, `npx boats --init`, follow prompts
 
 ## Docs
 [Full docsify documentation here](https://johndcarmichael.github.io/boats/)
@@ -22,6 +20,6 @@ Example files can be found here:
 - https://github.com/johndcarmichael/boats/tree/master/srcOA3
 
 ## Last publish reason
-v2 now injects the `package.json > name` as a prefix to permissions unless instructed not. 
+v2 now injects the `package.json > name` as a prefix to permissions unless instructed not.
 
-Please view the [changelog](https://johndcarmichael.github.io/boats/#/?id=changelog) for more details. 
+Please view the [changelog](https://johndcarmichael.github.io/boats/#/?id=changelog) for more details.

--- a/src/init.ts
+++ b/src/init.ts
@@ -2,12 +2,28 @@ import inquirer from 'inquirer';
 import fs from 'fs-extra';
 import path from 'path';
 import { BoatsRC } from '@/interfaces/BoatsRc';
+import boatsPackageJson from '../package.json';
+import { spawn } from 'child_process';
 
 const pwd = process.cwd();
 const srcPath = path.join(pwd, '/src');
 const srcAlreadyExists = fs.pathExistsSync(srcPath);
 const buildPath = path.join(pwd, '/build');
 const buildAlreadyExists = fs.pathExistsSync(srcPath);
+
+const npmInstall = () => new Promise<number>((resolve, reject) => {
+  spawn('npm', ['install'], {
+    stdio: 'inherit',
+    cwd: pwd
+  })
+    .on('close', (code) => {
+      if (code !== 0) {
+        return reject(Error('npm install command was unsuccessful'));
+      }
+
+      resolve(0);
+    });
+});
 
 if (srcAlreadyExists || buildAlreadyExists) {
   throw new Error(
@@ -26,6 +42,11 @@ if (!fs.pathExistsSync(localPkgJsonPath)) {
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const localPkgJson = require(localPkgJsonPath);
+
+localPkgJson.dependencies = {
+  ...(localPkgJson.dependencies || {}),
+  'boats': `^${boatsPackageJson.version}`
+};
 
 const questions = [
   {
@@ -49,7 +70,11 @@ const questions = [
   {
     type: 'list',
     name: 'oaType',
-    choices: ['Swagger 2.0', 'OpenAPI 3.0.0']
+    choices: [
+      'Swagger 2.0',
+      'OpenAPI 3.0.0',
+      'AsyncAPI 2.0.0'
+    ]
   },
   {
     type: 'confirm',
@@ -60,53 +85,63 @@ const questions = [
   }
 ];
 
-inquirer
-  .prompt(questions)
-  .then((answers) => {
-    if (answers.installConfirm) {
-      // write boatsrc to disc
-      const boatsrcDefault: BoatsRC = {
-        nunjucksOptions: {
-          tags: {}
-        },
-        jsonSchemaRefParserBundleOpts: {},
-        picomatchOptions: {
-          bash: true
-        },
-        permissionConfig: {
-          globalPrefix: true
-        }
-      };
-      fs.writeFileSync(path.join(pwd, '/.boatsrc'), JSON.stringify(boatsrcDefault, null, 4));
-      console.log('Completed: Injected a .boatsrc file');
-      fs.copySync(path.join(__dirname, '../../', answers.oaType === 'Swagger 2.0' ? 'srcOA2' : 'srcOA3'), srcPath);
-      console.log('Completed: Installed boats skeleton files to ' + srcPath);
-      fs.ensureDirSync(buildPath);
-      console.log('Completed: Created a build output directory');
-      const name = answers.name;
-      if (answers.updateName) {
-        localPkgJson.name = name;
-      }
-      localPkgJson['scripts']['build:json'] = 'boats -i ./src/index.yml.njk -o ./build/${npm_package_name}.json';
-      localPkgJson['scripts']['build:yaml'] = 'boats -i ./src/index.yml.njk -o ./build/${npm_package_name}.yml';
-      localPkgJson['scripts']['build'] = 'npm run build:json && npm run build:yaml';
+(async () => {
+  try {
+    const answers = await inquirer.prompt(questions);
 
-      // ensure the licence and private field is correct in the package.json
-      // we assume private by default and let the user correct otherwise.
-      delete localPkgJson.license;
-      localPkgJson.private = true;
-
-      // Write the new json object to file
-      fs.writeFileSync(localPkgJsonPath, JSON.stringify(localPkgJson, null, 4));
-      console.log('Completed: BOATS build scripts added to your package.json');
-      if (answers.updateName) {
-        return console.log('Completed: Package json name attr updated');
-      }
-    } else {
+    if (!answers.installConfirm) {
       return console.log('BOATS Installation cancelled.');
     }
-  })
-  .catch((e) => {
+
+    // write boatsrc to disc
+    const boatsrcDefault: BoatsRC = {
+      nunjucksOptions: {
+        tags: {}
+      },
+      jsonSchemaRefParserBundleOpts: {},
+      picomatchOptions: {
+        bash: true
+      },
+      permissionConfig: {
+        globalPrefix: true
+      }
+    };
+    fs.writeFileSync(path.join(pwd, '/.boatsrc'), JSON.stringify(boatsrcDefault, null, 4));
+    console.log('Completed: Injected a .boatsrc file');
+    if (answers.oaType === 'Swagger 2.0') {
+      fs.copySync(path.join(__dirname, '../../srcOA2'), srcPath);
+    } else if (answers.oaType === 'OpenAPI 3.0.0') {
+      fs.copySync(path.join(__dirname, '../../srcOA3'), srcPath);
+    } else if (answers.oaType === 'AsyncAPI 2.0.0') {
+      fs.copySync(path.join(__dirname, '../../srcASYNC2'), srcPath);
+    }
+    console.log('Completed: Installed boats skeleton files to ' + srcPath);
+    fs.ensureDirSync(buildPath);
+    console.log('Completed: Created a build output directory');
+    const name = answers.name;
+    if (answers.updateName) {
+      localPkgJson.name = name;
+    }
+    localPkgJson['scripts']['build:json'] = 'boats -i ./src/index.yml.njk -o ./build/${npm_package_name}.json';
+    localPkgJson['scripts']['build:yaml'] = 'boats -i ./src/index.yml.njk -o ./build/${npm_package_name}.yml';
+    localPkgJson['scripts']['build'] = 'npm run build:json && npm run build:yaml';
+
+    // ensure the licence and private field is correct in the package.json
+    // we assume private by default and let the user correct otherwise.
+    delete localPkgJson.license;
+    localPkgJson.private = true;
+
+    // Write the new json object to file
+    fs.writeFileSync(localPkgJsonPath, JSON.stringify(localPkgJson, null, 2));
+    console.log('Completed: BOATS build scripts added to your package.json');
+    if (answers.updateName) {
+      return console.log('Completed: Package json name attr updated');
+    }
+
+    await npmInstall();
+    console.log('Completed: Installed dependencies');
+  } catch (e) {
     console.log('Aborting installation:');
     console.error(e);
-  });
+  }
+})();

--- a/srcASYNC2/index.yml.njk
+++ b/srcASYNC2/index.yml.njk
@@ -1,8 +1,8 @@
 asyncapi: 2.0.0
 info:
-  title: {{ packageJson('name') }}
+  title: "{{ packageJson('name') }}"
   version: 1.0.1
-  description: {{ packageJson('description') }}
+  description: Beautiful Open / Async Template System - Write less yaml with BOATS and Nunjucks.
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0

--- a/srcOA2/index.yml.njk
+++ b/srcOA2/index.yml.njk
@@ -1,7 +1,7 @@
 swagger: "2.0"
 info:
     version: 1.0.1
-    title: {{ packageJson('name') }}
+    title: "{{ packageJson('name') }}"
     description: A sample API
     contact:
         name: Swagger API Team

--- a/srcOA3/index.yml.njk
+++ b/srcOA3/index.yml.njk
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   version: 1.0.1
-  title: {{ packageJson('name') }}
+  title: "{{ packageJson('name') }}"
   description: A sample API
   contact:
     name: Swagger API Team


### PR DESCRIPTION
fix: Make APIs work without description (default)
docs: Improve Readme.
feat: Add AsyncAPI3 and npm install to --init.